### PR TITLE
Fix files path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "name": "Coolrox95"
   },
   "files": [
-    "**/src/gameTypes",
-    "**/src/libraryTypes"
+    "src/gameTypes",
+    "src/libraryTypes"
   ],
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
Currently you can't pull this repo in and use it because the `files` property in `package.json` is incorrect. This simple change makes it so that you can include this repo in your mod's `package.json` file